### PR TITLE
Typo Error

### DIFF
--- a/Akeno/__init__.py
+++ b/Akeno/__init__.py
@@ -20,6 +20,7 @@ from pyrogram import filters
 from pyrogram.handlers import MessageHandler
 from pyrogram.raw.all import layer
 from pyrogram.types import *
+
 from Akeno.utils.logger import LOGS
 from config import API_HASH, API_ID, SESSION
 

--- a/Akeno/utils/custom.py
+++ b/Akeno/utils/custom.py
@@ -8,7 +8,9 @@ from os import getenv
 from traceback import format_exc
 from urllib.parse import unquote
 from urllib.request import urlretrieve
+
 from telegraph import Telegraph, exceptions, upload_file
+
 
 def QuoteApi(user_id, first_name, link, text):
     json = {

--- a/config.py
+++ b/config.py
@@ -11,8 +11,8 @@ GOOGLE_API_KEY = os.environ["GOOGLE_API_KEY"]
 MONGO_URL = os.environ["MONGO_URL"]
 CMD_HANDLER = getenv("CMD_HANDLER", ".")
 
-CHROME_DRIVER "/usr/bin/chromedriver"
-CHROME_BIN "/usr/bin/google-chrome-stable"
+CHROME_DRIVER = "/usr/bin/chromedriver"
+CHROME_BIN = "/usr/bin/google-chrome-stable"
 DWL_DIR = "./downloads/"
 TEMP_DIR = "./temp/"
 


### PR DESCRIPTION
  File "/usr/local/lib/python3.10/runpy.py", line 187, in _run_module
_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/local/lib/python3.10/runpy.py", line 146, in _get_module
_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/local/lib/python3.10/runpy.py", line 110, in _get_module
_details
    import(pkg_name)
  File "/.cache/Akeno/init.py", line 24, in <module>
    from config import API_HASH, API_ID, SESSION
  File "/.cache/config.py", line 14
    CHROME_DRIVER "/usr/bin/chromedriver"
                  ^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: invalid syntax